### PR TITLE
'handle' new unexpected event

### DIFF
--- a/src/KafkaJanitor.WebApp/Infrastructure/Messaging/MessageHandler.cs
+++ b/src/KafkaJanitor.WebApp/Infrastructure/Messaging/MessageHandler.cs
@@ -22,6 +22,9 @@ namespace KafkaJanitor.WebApp.Infrastructure.Messaging
                 case "topic_added":
                     var data = message.ReadDataAs<TopicAdded>();
                     return Handle(data);
+                case "topic_created":
+                    return HandleTopicCreated();
+                
                 default:
                     throw new Exception($"Unable to handle message {message.EventName}");
             }
@@ -37,6 +40,11 @@ namespace KafkaJanitor.WebApp.Infrastructure.Messaging
             }
 
             await _topicRepository.Add(new Topic(message.TopicName));
+        }
+
+        private async Task HandleTopicCreated()
+        {
+            // Do nothing as the payload sent by the new event is improper.
         }
 
         #region Message Definitions


### PR DESCRIPTION
Capability-service is sending a different event upon creation of a Topic. Both the name and payload is different. The payload however, contains "improper" data, and needs to be rectified before Kafka-janitor can use it.

Since everything Kafka-janitor is being used for is behind a feature flag, and isn't in "production use" so to speak, I've added a handler that doesn't exactly nothing with the event. That should prevent Kafka-janitor itself from hard crashing.