### PR TITLE
Kafka-Janitor: Ensure ACLs and api keypair are in place

### DIFF
--- a/local-development/access-interactions.rest
+++ b/local-development/access-interactions.rest
@@ -1,0 +1,12 @@
+###
+
+# Add a topic
+POST http://localhost:5000/api/access/request HTTP/1.1
+content-type: application/json
+
+{
+    "capabilityName": "capabilityname-{{$guid}}",
+    "capabilityId": "{{$guid}}",
+    "capabilityRootId": "capabilityname-{{$guid}}",
+    "topicPrefix" : "capabilityname"
+}

--- a/src/Infrastructure/KafkaJanitor.RestApi/Features/Access/Application/AccessService.cs
+++ b/src/Infrastructure/KafkaJanitor.RestApi/Features/Access/Application/AccessService.cs
@@ -7,20 +7,19 @@ using KafkaJanitor.RestApi.Features.ServiceAccounts.Infrastructure;
 using KafkaJanitor.RestApi.Features.Topics.Domain.Models;
 using KafkaJanitor.RestApi.Features.Vault;
 using KafkaJanitor.RestApi.Features.Vault.Model;
-using Microsoft.AspNetCore.Mvc;
 using Tika.RestClient.Features.ServiceAccounts.Models;
 
-namespace KafkaJanitor.RestApi.Features.Topics.Infrastructure
+namespace KafkaJanitor.RestApi.Features.Access.Application
 {
-    [Route(Routes.ACCESS_ROUTE)]
-    public class AccessController : ControllerBase
+    public class AccessService : IAccessService
     {
         private readonly IAccessControlListClient _accessControlListService;
         private readonly IServiceAccountClient _serviceAccountClient;
         private readonly IApiKeyClient _apiKeyClient;
         private readonly IVault _vault;
-        public AccessController(
-            IAccessControlListClient accessControlListService, 
+
+        public AccessService(
+            IAccessControlListClient accessControlListService,
             IServiceAccountClient serviceAccountClient,
             IApiKeyClient apiKeyClient,
             IVault vault
@@ -32,19 +31,14 @@ namespace KafkaJanitor.RestApi.Features.Topics.Infrastructure
             _vault = vault;
         }
 
-        [HttpPost("request")]
-        public async Task<IActionResult> RequestServiceAccount([FromBody] ServiceAccountRequestInput input)
+        public async Task ProvideAccess(
+            Capability cap,
+            string topicPrefix
+        )
         {
-            var cap = new Capability
-            {
-                Id = input.CapabilityId,
-                Name = input.CapabilityName,
-                RootId = input.CapabilityRootId
-            };
-
             ServiceAccount serviceAccount = null;
 
-            var doesServiceaccountExist = new Func<Task<bool>>(async () =>
+            Func<Task<bool>> doesServiceAccountExist = new Func<Task<bool>>(async () =>
             {
                 try
                 {
@@ -54,22 +48,25 @@ namespace KafkaJanitor.RestApi.Features.Topics.Infrastructure
                 {
                     return false;
                 }
+
                 return true;
             });
-            
-            var isExpectedAmountOfAclsInPlace = new Func<string,Task<bool>>(async (string serviceAccountId) =>
-            {
-                var acls = await _accessControlListService.GetAclsForServiceAccount(serviceAccountId);
-                return acls.Count() == 12;
-            });
-            
-            var isExpectedAmountOfApiKeysInPlace = new Func<string,Task<bool>>(async (string serviceAccountId) =>
-            {
-                var apiKeys = await _apiKeyClient.GetApiKeyPairsForServiceAccount(serviceAccountId);
-                return apiKeys.Any();
-            });
-            
-            if (!await doesServiceaccountExist())
+
+            Func<string, Task<bool>> isExpectedAmountOfAclsInPlace = new Func<string, Task<bool>>(
+                async (string serviceAccountId) =>
+                {
+                    var acls = await _accessControlListService.GetAclsForServiceAccount(serviceAccountId);
+                    return acls.Count() == 12;
+                });
+
+            Func<string, Task<bool>> isExpectedAmountOfApiKeysInPlace = new Func<string, Task<bool>>(
+                async (string serviceAccountId) =>
+                {
+                    var apiKeys = await _apiKeyClient.GetApiKeyPairsForServiceAccount(serviceAccountId);
+                    return apiKeys.Any();
+                });
+
+            if (!await doesServiceAccountExist())
             {
                 serviceAccount = await _serviceAccountClient.CreateServiceAccount(cap);
             }
@@ -80,7 +77,7 @@ namespace KafkaJanitor.RestApi.Features.Topics.Infrastructure
 
             if (!await isExpectedAmountOfAclsInPlace(serviceAccount.Id))
             {
-                await _accessControlListService.CreateAclsForServiceAccount(serviceAccount.Id, input.TopicPrefix);
+                await _accessControlListService.CreateAclsForServiceAccount(serviceAccount.Id, topicPrefix);
             }
 
             if (!await isExpectedAmountOfApiKeysInPlace(serviceAccount.Id))
@@ -88,25 +85,14 @@ namespace KafkaJanitor.RestApi.Features.Topics.Infrastructure
                 var apiKeyPair = await _apiKeyClient.CreateApiKeyPair(serviceAccount);
 
                 await _vault.AddApiCredentials(
-                    cap, 
+                    cap,
                     new ApiCredentials
                     {
                         Key = apiKeyPair.Key,
                         Secret = apiKeyPair.Secret
                     }
-                );   
+                );
             }
-
-            return Ok();
         }
-
-    }
-    
-    public class ServiceAccountRequestInput
-    {
-        public string CapabilityName { get; set; }
-        public string CapabilityId { get; set; }
-        public string CapabilityRootId { get; set; }
-        public string TopicPrefix { get; set; }
     }
 }

--- a/src/Infrastructure/KafkaJanitor.RestApi/Features/Access/Application/AccessService.cs
+++ b/src/Infrastructure/KafkaJanitor.RestApi/Features/Access/Application/AccessService.cs
@@ -37,12 +37,15 @@ namespace KafkaJanitor.RestApi.Features.Access.Application
             string topicPrefix
         )
         {
+            
             ServiceAccount serviceAccount;
-            if (!await ServiceAccountExists(capability))
+
+            try
             {
+                // ServiceAccountClient should throw a ServiceAccountExists exception. But this is the best we got for now
                 serviceAccount = await _serviceAccountClient.CreateServiceAccount(capability);
             }
-            else
+            catch (System.Net.Http.HttpRequestException e) when(e.Message.Contains("409"))
             {
                 serviceAccount = await _serviceAccountClient.GetServiceAccount(capability);
             }

--- a/src/Infrastructure/KafkaJanitor.RestApi/Features/Access/Application/AccessService.cs
+++ b/src/Infrastructure/KafkaJanitor.RestApi/Features/Access/Application/AccessService.cs
@@ -80,20 +80,6 @@ namespace KafkaJanitor.RestApi.Features.Access.Application
                 }
             );
         }
-        
-        public async Task<bool> ServiceAccountExists(Capability capability)
-        {
-            try
-            {
-                var sa = await _serviceAccountClient.GetServiceAccount(capability);
-            }
-            catch (InvalidOperationException ex)
-            {
-                return false;
-            }
-
-            return true;
-        }
 
         public async Task<bool> ExpectedAmountOfAclsAreInPlace(string serviceAccountId)
         {

--- a/src/Infrastructure/KafkaJanitor.RestApi/Features/Access/Application/AccessService.cs
+++ b/src/Infrastructure/KafkaJanitor.RestApi/Features/Access/Application/AccessService.cs
@@ -55,7 +55,7 @@ namespace KafkaJanitor.RestApi.Features.Access.Application
                 await _accessControlListService.CreateAclsForServiceAccount(serviceAccount.Id, topicPrefix);
             }
 
-            if (!await AtLestOneApiKeyExists(serviceAccount.Id))
+            if (!await AtLeastOneApiKeyExists(serviceAccount.Id))
             {
                 await CreateAndStoreApiKeyPair(
                     capability, 
@@ -102,7 +102,7 @@ namespace KafkaJanitor.RestApi.Features.Access.Application
             return acls.Count() == expectedAclCount;
         }
 
-        public async Task<bool> AtLestOneApiKeyExists(string serviceAccountId)
+        public async Task<bool> AtLeastOneApiKeyExists(string serviceAccountId)
         {
             var apiKeys = await _apiKeyClient.GetApiKeyPairsForServiceAccount(serviceAccountId);
             return apiKeys.Any();

--- a/src/Infrastructure/KafkaJanitor.RestApi/Features/Access/Application/IAccessService.cs
+++ b/src/Infrastructure/KafkaJanitor.RestApi/Features/Access/Application/IAccessService.cs
@@ -6,7 +6,7 @@ namespace KafkaJanitor.RestApi.Features.Access.Application
     public interface IAccessService
     {
         Task ProvideAccess(
-            Capability cap,
+            Capability capability,
             string topicPrefix
         );
     }

--- a/src/Infrastructure/KafkaJanitor.RestApi/Features/Access/Application/IAccessService.cs
+++ b/src/Infrastructure/KafkaJanitor.RestApi/Features/Access/Application/IAccessService.cs
@@ -1,0 +1,13 @@
+using System.Threading.Tasks;
+using KafkaJanitor.RestApi.Features.Topics.Domain.Models;
+
+namespace KafkaJanitor.RestApi.Features.Access.Application
+{
+    public interface IAccessService
+    {
+        Task ProvideAccess(
+            Capability cap,
+            string topicPrefix
+        );
+    }
+}

--- a/src/Infrastructure/KafkaJanitor.RestApi/Features/Access/Infrastructure/AccessController.cs
+++ b/src/Infrastructure/KafkaJanitor.RestApi/Features/Access/Infrastructure/AccessController.cs
@@ -1,0 +1,45 @@
+using System.Threading.Tasks;
+using KafkaJanitor.RestApi.Features.Access.Application;
+using KafkaJanitor.RestApi.Features.Topics.Domain.Models;
+using Microsoft.AspNetCore.Mvc;
+
+namespace KafkaJanitor.RestApi.Features.Access.Infrastructure
+{
+    [Route(Routes.ACCESS_ROUTE)]
+    public class AccessController : ControllerBase
+    {
+        private readonly IAccessService _accessService;
+
+        public AccessController(IAccessService accessService)
+        {
+            _accessService = accessService;
+        }
+        
+        [HttpPost("request")]
+        public async Task<IActionResult> RequestServiceAccount([FromBody] ServiceAccountRequestInput input)
+        {
+            var capability = new Capability
+            {
+                Id = input.CapabilityId,
+                Name = input.CapabilityName,
+                RootId = input.CapabilityRootId
+            };
+            
+            await _accessService.ProvideAccess(
+                capability, 
+                input.TopicPrefix
+            );
+         
+            return Ok();
+        }
+
+    }
+    
+    public class ServiceAccountRequestInput
+    {
+        public string CapabilityName { get; set; }
+        public string CapabilityId { get; set; }
+        public string CapabilityRootId { get; set; }
+        public string TopicPrefix { get; set; }
+    }
+}

--- a/src/Infrastructure/KafkaJanitor.RestApi/Features/AccessControlLists/Infrastructure/AccessControlListClient.cs
+++ b/src/Infrastructure/KafkaJanitor.RestApi/Features/AccessControlLists/Infrastructure/AccessControlListClient.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Tika.RestClient;
 using Tika.RestClient.Features.Acls.Models;
@@ -37,6 +39,13 @@ namespace KafkaJanitor.RestApi.Features.AccessControlLists.Infrastructure
             await _tikaClient.Acls.CreateAsync(new AclCreateDelete(serviceAccountIdAsInt, false, "alter-configs"));
             await _tikaClient.Acls.CreateAsync(new AclCreateDelete(serviceAccountIdAsInt, false, "cluster-action"));
             await _tikaClient.Acls.CreateAsync(new AclCreateDelete(serviceAccountIdAsInt, false, "create", "'*'"));
+        }
+
+        public async Task<IEnumerable<Acl>> GetAclsForServiceAccount(string serviceAccountId)
+        {
+            var serviceAccountIdAsInt = Convert.ToInt64(serviceAccountId);
+            var results = await _tikaClient.Acls.GetAllAsync();
+            return results.Where(acl => acl.ServiceAccountId == serviceAccountIdAsInt);
         }
     }
 }

--- a/src/Infrastructure/KafkaJanitor.RestApi/Features/AccessControlLists/Infrastructure/IAccessControlListClient.cs
+++ b/src/Infrastructure/KafkaJanitor.RestApi/Features/AccessControlLists/Infrastructure/IAccessControlListClient.cs
@@ -1,9 +1,12 @@
+using System.Collections.Generic;
 using System.Threading.Tasks;
+using Tika.RestClient.Features.Acls.Models;
 
 namespace KafkaJanitor.RestApi.Features.AccessControlLists.Infrastructure
 {
     public interface IAccessControlListClient
     {
         Task CreateAclsForServiceAccount(string serviceAccountId, string prefix);
+        Task<IEnumerable<Acl>> GetAclsForServiceAccount(string serviceAccountId);
     }
 }

--- a/src/Infrastructure/KafkaJanitor.RestApi/Features/ApiKeys/ApiKeyClient.cs
+++ b/src/Infrastructure/KafkaJanitor.RestApi/Features/ApiKeys/ApiKeyClient.cs
@@ -1,4 +1,6 @@
-﻿using System.Threading.Tasks;
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
 using Tika.RestClient;
 using Tika.RestClient.Features.ApiKeys.Models;
 using Tika.RestClient.Features.ServiceAccounts.Models;
@@ -21,6 +23,13 @@ namespace KafkaJanitor.RestApi.Features.ApiKeys
                 Description = "Automatically created during SA flow",
                 ServiceAccountId = serviceAccount.Id
             });
+        }
+
+        public async Task<IEnumerable<ApiKey>> GetApiKeyPairsForServiceAccount(string serviceAccountId)
+        {
+            var result = await _tikaClient.ApiKeys.GetAllAsync();
+
+            return result.Where(ak => ak.Owner == serviceAccountId);
         }
     }
 }

--- a/src/Infrastructure/KafkaJanitor.RestApi/Features/ApiKeys/IApiKeyClient.cs
+++ b/src/Infrastructure/KafkaJanitor.RestApi/Features/ApiKeys/IApiKeyClient.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 using Tika.RestClient.Features.ApiKeys.Models;
 using Tika.RestClient.Features.ServiceAccounts.Models;
 
@@ -7,5 +8,6 @@ namespace KafkaJanitor.RestApi.Features.ApiKeys
     public interface IApiKeyClient
     {
         Task<ApiKey> CreateApiKeyPair(ServiceAccount serviceAccount);
+        Task<IEnumerable<ApiKey>> GetApiKeyPairsForServiceAccount(string serviceAccountId);
     }
 }

--- a/src/Infrastructure/KafkaJanitor.RestApi/Features/ServiceAccounts/Infrastructure/IServiceAccountClient.cs
+++ b/src/Infrastructure/KafkaJanitor.RestApi/Features/ServiceAccounts/Infrastructure/IServiceAccountClient.cs
@@ -8,5 +8,6 @@ namespace KafkaJanitor.RestApi.Features.ServiceAccounts.Infrastructure
     public interface IServiceAccountClient
     {
         Task<ServiceAccount> CreateServiceAccount(Capability capability);
+        Task<ServiceAccount> GetServiceAccount(Capability capability);
     }
 }

--- a/src/Infrastructure/KafkaJanitor.RestApi/Features/ServiceAccounts/Infrastructure/ServiceAccountClient.cs
+++ b/src/Infrastructure/KafkaJanitor.RestApi/Features/ServiceAccounts/Infrastructure/ServiceAccountClient.cs
@@ -24,7 +24,7 @@ namespace KafkaJanitor.RestApi.Features.ServiceAccounts.Infrastructure
         public async Task<ServiceAccount> GetServiceAccount(Capability capability)
         {
             var results = await _tikaClient.ServiceAccounts.GetAllAsync();
-            return results.First(sa => sa.Name == $"{capability.Name}_sa");
+            return results.Single(sa => sa.Name == $"{capability.Name}_sa");
         }
     }
 }

--- a/src/Infrastructure/KafkaJanitor.RestApi/Features/ServiceAccounts/Infrastructure/ServiceAccountClient.cs
+++ b/src/Infrastructure/KafkaJanitor.RestApi/Features/ServiceAccounts/Infrastructure/ServiceAccountClient.cs
@@ -1,5 +1,5 @@
+using System.Linq;
 using System.Threading.Tasks;
-using KafkaJanitor.RestApi.Features.Topics;
 using KafkaJanitor.RestApi.Features.Topics.Domain.Models;
 using Tika.RestClient;
 using Tika.RestClient.Features.ServiceAccounts.Models;
@@ -20,6 +20,11 @@ namespace KafkaJanitor.RestApi.Features.ServiceAccounts.Infrastructure
                 name = $"{capability.Name}_sa",
                 description = "Creating with TikaService using KafkaJanitor"
             });
+        }
+        public async Task<ServiceAccount> GetServiceAccount(Capability capability)
+        {
+            var results = await _tikaClient.ServiceAccounts.GetAllAsync();
+            return results.First(sa => sa.Name == $"{capability.Name}_sa");
         }
     }
 }

--- a/src/Infrastructure/KafkaJanitor.RestApi/KafkaJanitor.RestApi.csproj
+++ b/src/Infrastructure/KafkaJanitor.RestApi/KafkaJanitor.RestApi.csproj
@@ -10,7 +10,7 @@
       <PackageReference Include="AWSSDK.SimpleSystemsManagement" Version="3.3.118.3" />
       <PackageReference Include="Confluent.Kafka" Version="1.0.1" />
       <PackageReference Include="prometheus-net.AspNetCore" Version="3.4.0" />
-      <PackageReference Include="Tika.RestClient" Version="0.0.7" />
+      <PackageReference Include="Tika.RestClient" Version="0.0.8" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Infrastructure/KafkaJanitor.RestApi/Properties/launchSettings.json
+++ b/src/Infrastructure/KafkaJanitor.RestApi/Properties/launchSettings.json
@@ -25,6 +25,8 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "TIKA_API_ENDPOINT": "http://localhost:3000",
+        "KAFKAJANITOR_VAULT": "INMEMORY",
+        "KAFKAJANITOR_START_METRIC_SERVER": "true"
       }
     }
   }

--- a/src/Infrastructure/KafkaJanitor.RestApi/Startup.cs
+++ b/src/Infrastructure/KafkaJanitor.RestApi/Startup.cs
@@ -1,6 +1,6 @@
-using System;
 using KafkaJanitor.RestApi.Enablers.Metrics;
 using KafkaJanitor.RestApi.Enablers.PrometheusHealthCheck;
+using KafkaJanitor.RestApi.Features.Access.Application;
 using KafkaJanitor.RestApi.Features.AccessControlLists.Infrastructure;
 using KafkaJanitor.RestApi.Features.ApiKeys;
 using KafkaJanitor.RestApi.Features.ServiceAccounts.Infrastructure;
@@ -56,6 +56,8 @@ namespace KafkaJanitor.RestApi
                 }
             });
 
+            services.AddTransient<IAccessService, AccessService>();
+            
             // Enablers
             var shouldStartMetricHostedService = Configuration["KAFKAJANITOR_START_METRIC_SERVER"] != "false";
             services.AddMetrics(shouldStartMetricHostedService);

--- a/src/Infrastructure/KafkaJanitor.RestClient/Features/Access/AccessClient.cs
+++ b/src/Infrastructure/KafkaJanitor.RestClient/Features/Access/AccessClient.cs
@@ -1,7 +1,9 @@
 using System;
+using System.Net;
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
+using KafkaJanitor.RestClient.Features.Access.Exceptions;
 using KafkaJanitor.RestClient.Features.Access.Models;
 using Newtonsoft.Json;
 
@@ -28,10 +30,15 @@ namespace KafkaJanitor.RestClient.Features.Access
                 "application/json"
             );
 
-            await _httpClient.PostAsync(
+            var httpResponseMessage = await _httpClient.PostAsync(
                 new Uri($"{ACCESS_ROUTE}request", UriKind.Relative),
                 content
             );
+
+            if (httpResponseMessage.StatusCode != HttpStatusCode.OK)
+            {
+                throw new GrantingAccessException(input.CapabilityRootId, httpResponseMessage.StatusCode);
+            }
         }
     }
 }

--- a/src/Infrastructure/KafkaJanitor.RestClient/Features/Access/Exceptions/GrantingAccessException.cs
+++ b/src/Infrastructure/KafkaJanitor.RestClient/Features/Access/Exceptions/GrantingAccessException.cs
@@ -1,0 +1,11 @@
+using System;
+using System.Net;
+
+namespace KafkaJanitor.RestClient.Features.Access.Exceptions
+{
+    public class GrantingAccessException : Exception
+    {
+        public GrantingAccessException(string capabilityRootId, HttpStatusCode httpStatusCode) : base(
+            $"Failed to grant access to capabilityRootId: '{capabilityRootId}', httpstatus code returned: '({(int)httpStatusCode}) {httpStatusCode}'"){}
+    }
+}

--- a/src/KafkaJanitor.IntegrationTests/AccessInSuccessionScenario.cs
+++ b/src/KafkaJanitor.IntegrationTests/AccessInSuccessionScenario.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading.Tasks;
+using KafkaJanitor.RestClient;
+using KafkaJanitor.RestClient.Factories;
+using KafkaJanitor.RestClient.Features.Access.Models;
+using Microsoft.Extensions.Hosting;
+using Xunit;
+
+namespace KafkaJanitor.IntegrationTests
+{
+    public class AccessInSuccessionScenario
+    {
+        private IHost testHost;
+        private IRestClient restClient;
+
+        private ServiceAccountRequestInput serviceAccountRequestInput;
+        private List<Task> _tasks = new List<Task>();
+
+        [Fact]
+        public async Task AccessInSuccessionScenarioRecipe()
+        {
+                  Given_a_rest_client();
+                  When_access_is_requested();
+                  And_same_access_is_requested();
+            await Then_no_exceptions_are_thrown();
+        }
+
+        private void Given_a_rest_client()
+        {
+            var httpClient = new HttpClient();
+            httpClient.BaseAddress = new Uri("http://localhost:5000");
+            restClient = RestClientFactory.Create(httpClient);
+        }
+
+        private void When_access_is_requested()
+        {
+            var capabilityName =
+                "test-capability-name-" +
+                Guid.NewGuid().ToString()
+                    .Substring(0, 5);
+
+            serviceAccountRequestInput = new ServiceAccountRequestInput
+            {
+                CapabilityId = Guid.NewGuid().ToString(),
+                CapabilityName = capabilityName,
+                TopicPrefix = capabilityName,
+                CapabilityRootId = "root-id-" + capabilityName
+            };
+
+            _tasks.Add(restClient.Access.RequestAsync(serviceAccountRequestInput));
+        }
+
+        private async Task And_same_access_is_requested()
+        {
+            _tasks.Add(restClient.Access.RequestAsync(serviceAccountRequestInput));
+        }
+
+        private async Task Then_no_exceptions_are_thrown()
+        {
+            await Task.WhenAll(_tasks);
+        }
+    }
+}

--- a/src/KafkaJanitor.IntegrationTests/KafkaJanitor.IntegrationTests.csproj
+++ b/src/KafkaJanitor.IntegrationTests/KafkaJanitor.IntegrationTests.csproj
@@ -21,6 +21,7 @@
 
     <ItemGroup>
       <ProjectReference Include="..\Infrastructure\KafkaJanitor.RestApi\KafkaJanitor.RestApi.csproj" />
+      <ProjectReference Include="..\Infrastructure\KafkaJanitor.RestClient\KafkaJanitor.RestClient.csproj" />
     </ItemGroup>
 
 </Project>

--- a/src/KafkaJanitor.IntegrationTests/KafkaJanitor.IntegrationTests.csproj
+++ b/src/KafkaJanitor.IntegrationTests/KafkaJanitor.IntegrationTests.csproj
@@ -14,7 +14,7 @@
         <PackageReference Include="Microsoft.Extensions.Options" Version="3.1.1" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
         <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-        <PackageReference Include="Tika.RestClient" Version="0.0.7" />
+        <PackageReference Include="Tika.RestClient" Version="0.0.8" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
     </ItemGroup>


### PR DESCRIPTION
- Added checks that ensure ServiceAccounts, ACLs, and a default API keypair is available, whenever the '/access/request' endpoint is hit, which is whenever a topic is created.
- Updated integration test to cover creation and deletion of API keypair

How do we feel about keeping a fair bit of functionality in the AccessController @kim-lindhard-dfds ? Still want to move it out? I'm currently feeling a bit indifferent since said Controller only has one method/action, however if we want to adhere to some standard/belief that Controllers should be kept clean from logic like this, I'm also fine with that.

Story details: https://app.clubhouse.io/devex/story/1728