### PR TITLE
Increased CPU limit for Tika client

### DIFF
--- a/k8s/deployment.yml
+++ b/k8s/deployment.yml
@@ -79,7 +79,7 @@ spec:
             cpu: "100m"
           limits:
             memory: "128Mi"
-            cpu: "200m"
+            cpu: "400m"
         env:
         - name: TIKA_CCLOUD_CLUSTER_ID
           value: $(TIKA_CCLOUD_CLUSTER_ID)


### PR DESCRIPTION
Increased CPU limit for Tika client from 200Mi to 400Mi to avoid CPU throttling