### PR TITLE
Added Kafka Connect ACLs

### DIFF
--- a/src/Infrastructure/KafkaJanitor.RestApi/Features/AccessControlLists/Domain/Models/AccessControlLists.cs
+++ b/src/Infrastructure/KafkaJanitor.RestApi/Features/AccessControlLists/Domain/Models/AccessControlLists.cs
@@ -30,7 +30,7 @@ namespace KafkaJanitor.RestApi.Features.AccessControlLists.Domain.Models
                 // For root-id.*
                 new AclCreateDelete(serviceAccountIdAsInt, true, "WRITE", "", prefix),
                 new AclCreateDelete(serviceAccountIdAsInt, true, "CREATE", "", prefix),
-                new AclCreateDelete(serviceAccountIdAsInt, true, "READ", "", prefix)
+                new AclCreateDelete(serviceAccountIdAsInt, true, "READ", "", prefix),
                     
                 // For connect-rootid.*
                 new AclCreateDelete(serviceAccountIdAsInt, true, "WRITE", "", $"connect-{prefix}"),

--- a/src/Infrastructure/KafkaJanitor.RestApi/Features/AccessControlLists/Domain/Models/AccessControlLists.cs
+++ b/src/Infrastructure/KafkaJanitor.RestApi/Features/AccessControlLists/Domain/Models/AccessControlLists.cs
@@ -27,9 +27,15 @@ namespace KafkaJanitor.RestApi.Features.AccessControlLists.Domain.Models
         {
             return new[]
             {
+                // For root-id.*
                 new AclCreateDelete(serviceAccountIdAsInt, true, "WRITE", "", prefix),
                 new AclCreateDelete(serviceAccountIdAsInt, true, "CREATE", "", prefix),
                 new AclCreateDelete(serviceAccountIdAsInt, true, "READ", "", prefix)
+                    
+                // For connect-rootid.*
+                new AclCreateDelete(serviceAccountIdAsInt, true, "WRITE", "", $"connect-{prefix}"),
+                new AclCreateDelete(serviceAccountIdAsInt, true, "CREATE", "", $"connect-{prefix}"),
+                new AclCreateDelete(serviceAccountIdAsInt, true, "READ", "", $"connect-{prefix}")
             };
         }
 


### PR DESCRIPTION
Talked with Michael to determine what ACLs are required to make this work. According to the discussion attached below, it seems only 3 extra ACLs are required.
<img width="1073" alt="Screenshot 2021-03-23 at 10 40 21 AM" src="https://user-images.githubusercontent.com/1633308/112126028-545a7f80-8bc4-11eb-94d2-d7685b24c25e.png">



Numbers before cleaning up:

- Service accounts: 138
- Current amount of ACLs per SvcAcc: 15
- Amount of ACLs after change: 18

Total: 2070 ACLs
Total after update: **2484**

---

Numbers after cleaning up:

- Service accounts: 43
- Current amount of ACLs per SvcAcc: 15
- Amount of ACLs after change: 18


Total: 645 ACLs
Total after update: **774**
